### PR TITLE
fix: encode URIs to comply w/ W3c guidelines

### DIFF
--- a/classes/KirbyExtended/BlurryPlaceholder.php
+++ b/classes/KirbyExtended/BlurryPlaceholder.php
@@ -59,7 +59,8 @@ class BlurryPlaceholder
         $svg = static::image($file, $ratio);
         $dataUri = 'data:image/svg+xml;charset=utf-8,' . static::svgToUri($svg);
 
-        return $dataUri;
+        // Encode string to be compliant with W3C guidelines
+        return urlencode($dataUri);
     }
 
     /**

--- a/classes/KirbyExtended/BlurryPlaceholder.php
+++ b/classes/KirbyExtended/BlurryPlaceholder.php
@@ -59,8 +59,7 @@ class BlurryPlaceholder
         $svg = static::image($file, $ratio);
         $dataUri = 'data:image/svg+xml;charset=utf-8,' . static::svgToUri($svg);
 
-        // Encode string to be compliant with W3C guidelines
-        return urlencode($dataUri);
+        return $dataUri;
     }
 
     /**
@@ -79,9 +78,10 @@ class BlurryPlaceholder
         $data = rawurlencode($data);
 
         // Back-decode certain characters to improve compression
+        // except '%20' to be compliant with W3C guidelines
         $data = str_replace(
-            ['%20', '%2F', '%3A', '%3D'],
-            [' ', '/', ':', '='],
+            ['%2F', '%3A', '%3D'],
+            ['/', ':', '='],
             $data
         );
 


### PR DESCRIPTION
Using https://validator.w3.org/ on a site with Kirby Blurry Placeholder throws a bunch of errors like this:
<img width="1893" alt="CleanShot 2022-02-08 at 21 51 51@2x" src="https://user-images.githubusercontent.com/29142128/153073606-828ddfbb-0746-4888-81ae-9bd86037f28e.png">
This PR fixes those errors.