### PR TITLE
fix: kirbytext inline deprecation since 3.7

### DIFF
--- a/tags/blurryimage.php
+++ b/tags/blurryimage.php
@@ -76,7 +76,9 @@ return [
 
         // render KirbyText in caption
         if ($tag->caption) {
-            $tag->caption = [$tag->kirby()->kirbytext($tag->caption, [], true)];
+            $tag->caption = [$tag->kirby()->kirbytext($tag->caption, [
+                'markdown' => ['inline' => true],
+            ])];
         }
 
         return Html::figure([$link($image)], $tag->caption, [


### PR DESCRIPTION
Now uses the option parameter since third `$inline` parameter is deprecated in kirby 3.7 and will be removed in 3.8

See: https://getkirby.com/releases/3.7#changes